### PR TITLE
Fixed issue with deleting labels in debugger list

### DIFF
--- a/UI/Debugger/Labels/ctrlLabelList.cs
+++ b/UI/Debugger/Labels/ctrlLabelList.cs
@@ -222,7 +222,6 @@ namespace Mesen.GUI.Debugger.Controls
 		private void mnuDelete_Click(object sender, EventArgs e)
 		{
 			if(lstLabels.SelectedIndices.Count > 0) {
-				int topIndex = lstLabels.TopItem.Index;
 				int lastSelectedIndex = lstLabels.SelectedIndices[lstLabels.SelectedIndices.Count - 1];
 				List<int> selectedIndexes = new List<int>(lstLabels.SelectedIndices.Cast<int>().ToList());
 				for(int i = selectedIndexes.Count - 1; i >= 0; i--) {
@@ -230,10 +229,7 @@ namespace Mesen.GUI.Debugger.Controls
 					LabelManager.DeleteLabel(label, i == 0);
 				}
 				
-				//Reposition scroll bar and selected/focused item
-				if(lstLabels.Items.Count > topIndex) {
-					lstLabels.TopItem = lstLabels.Items[topIndex];
-				}
+				//Reposition selected/focused item
 				if(lastSelectedIndex < lstLabels.Items.Count) {
 					lstLabels.Items[lastSelectedIndex].Selected = true;
 				} else if(lstLabels.Items.Count > 0) {


### PR DESCRIPTION
When having the debugger label list horizontally scrolled, deleting
labels would cause an exception, since the TopItem property would
suddenly become null. Removing all logic related to TopItem seems to fix
the issue, without any side-effects.
If this causes side-effects on other platforms (that don't use mono),
another fix could be to explicitly check for null and skip the logic if
that's the case.